### PR TITLE
with_original_env so BUNDLER_APP_CONFIG is honored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix binstubs not being replaced when their quoting style was changed (#534)
 * Preserve comments right after the shebang line which might include magic comments such as `frozen_string_literal: true'
+* Fix binstub failures when Bundler's `BUNDLE_APP_CONFIG` environment variable is present (#545)
 
 ## 2.0.2
 

--- a/lib/spring/application_manager.rb
+++ b/lib/spring/application_manager.rb
@@ -92,7 +92,7 @@ module Spring
     def start_child(preload = false)
       @child, child_socket = UNIXSocket.pair
 
-      Bundler.with_clean_env do
+      Bundler.with_original_env do
         @pid = Process.spawn(
           {
             "RAILS_ENV"           => app_env,


### PR DESCRIPTION
Bundler's `with_clean_env` completely erases all Bundler-related
environment variables, even if those variables existed prior to loading
Bundler. That means that custom Bundler settings that we legitimately
want to pass down to child processes - namely, `BUNDLE_APP_CONFIG` - are
erased, leading to errors when the child process loads `bundler/setup`.

Note that `with_clean_env` is actually deprecated by Bundler. The method
recommended by Bundler going forward, and the one used in this commit,
is `with_original_env`. This clears any variables that were set by
Bundler itself, but retains any user-supplied settings that existed
prior.

This fixes a bug where spring binstubs would fail if `BUNDLE_APP_CONFIG`
was set to a custom location (i.e. other than the default `./.bundle`)
and `bundle install --path` was used. The binstub would not be able to
load the bundle because without `BUNDLE_APP_CONFIG`, it could not know
the path where the gems were installed.